### PR TITLE
modification pour récupérer le titre des annonces sur les pages de 15

### DIFF
--- a/notebooks/victor/paruvendu/paruvendu.ipynb
+++ b/notebooks/victor/paruvendu/paruvendu.ipynb
@@ -75,35 +75,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([30])"
+       "array([1, 2])"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "pages = np.arange(30, 31)\n",
+    "pages = np.arange(1, 3)\n",
     "pages"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "x15 saved: 30\n"
+      "x15 saved: 1\n",
+      "x15 saved: 2\n"
      ]
     }
    ],
@@ -132,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -141,7 +142,7 @@
        "'paruvendu-2021-06-02_21h20-30.html'"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -153,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -162,7 +163,7 @@
        "'pages/paruvendu-2021-06-02_21h20-30.html'"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -181,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -215,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 12,
    "metadata": {
     "scrolled": false
    },
@@ -240,7 +241,7 @@
        " 10250.0]"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -268,7 +269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -319,7 +320,7 @@
        " '1250913038']"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -340,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -372,7 +373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 16,
    "metadata": {
     "scrolled": false
    },
@@ -397,7 +398,7 @@
        " 'https://www.paruvendu.fr/a/moto-scooter/moto/ducati/1198-cm3/1250913038A1KVMOMODU']"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -407,6 +408,182 @@
     "    readable_html = f.read()\n",
     "    urls_list = get_urls_from_saved_x15(readable_html)\n",
     "urls_list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get title from saved x15"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_titles_from_saved_x15(r):\n",
+    "    \n",
+    "    # set empty title list\n",
+    "    title_list = []\n",
+    "    \n",
+    "    # get soup\n",
+    "    soup = BeautifulSoup(r, 'html.parser')\n",
+    "    \n",
+    "    # extract title\n",
+    "    step1 = soup.select('div[class*=\"lazyload_bloc\"]')\n",
+    "    if len(step1)>0:\n",
+    "        for k in step1:\n",
+    "            step2 = k.find_all(\"h3\")\n",
+    "            if len(step2)>0:\n",
+    "                title_list.append(step2[0].text.replace(\"\\n\", \"\").replace(\"\\t\", \"\").replace(\"Moto \", \"\").strip())\n",
+    "            else:\n",
+    "                title_list.append(np.nan)\n",
+    "    else:\n",
+    "        return None\n",
+    "    #\n",
+    "    return title_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['BMW',\n",
+       " 'YAMAHA',\n",
+       " 'SUZUKI',\n",
+       " 'HARLEY-DAVIDSON',\n",
+       " 'YAMAHA',\n",
+       " 'KAWASAKI',\n",
+       " 'ROYAL ENFIELD',\n",
+       " 'YAMAHA',\n",
+       " 'HARLEY-DAVIDSON',\n",
+       " 'HONDA',\n",
+       " 'HARLEY-DAVIDSON',\n",
+       " 'TRIUMPH',\n",
+       " 'KAWASAKI',\n",
+       " 'SUZUKI',\n",
+       " 'DUCATI 1198 s']"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with open(file_check_x15_good, 'r') as f:\n",
+    "    readable_html = f.read()\n",
+    "    title_list = get_titles_from_saved_x15(readable_html)\n",
+    "title_list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## temp df template"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>url</th>\n",
+       "      <th>unique id</th>\n",
+       "      <th>price</th>\n",
+       "      <th>title</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   url  unique id  price  title\n",
+       "0  NaN        NaN    NaN    NaN"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "temp_template = pd.DataFrame({\"url\": [np.nan],\n",
+    "                              \"unique id\": [np.nan],\n",
+    "                              \"price\": [np.nan],\n",
+    "                              \"title\": [np.nan]\n",
+    "                            })\n",
+    "temp_template"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def save_temporary_data(url_, uniq_id_, price_, title_):\n",
+    "\n",
+    "    # load csv if exists or starting from template\n",
+    "    data_paruvendu = \"../../../tresboncoin/data/paruvendu_ad.csv\"\n",
+    "    #\n",
+    "    if os.path.isfile(data_paruvendu) is False:\n",
+    "        df = temp_template.copy()\n",
+    "    else:\n",
+    "        data = pd.read_csv(data_paruvendu)\n",
+    "        df = temp_template.copy()\n",
+    "        \n",
+    "    # adding data\n",
+    "    df[\"url\"] = url_\n",
+    "    df[\"unique id\"] = uniq_id_\n",
+    "    df[\"price\"] = price_\n",
+    "    df[\"title\"] = title_\n",
+    "    \n",
+    "    # concatenate to csv and write\n",
+    "    try:\n",
+    "        data = pd.concat([data, df], axis=0)\n",
+    "        data.to_csv(path_or_buf = data_paruvendu, index=False)\n",
+    "    except:\n",
+    "        df.to_csv(path_or_buf = data_paruvendu, index=False)\n",
+    "        \n",
+    "    return"
    ]
   },
   {
@@ -425,7 +602,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -434,7 +611,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -443,16 +620,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(1246, 20)"
+       "(1283, 20)"
       ]
      },
-     "execution_count": 83,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -508,159 +685,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/suzuki/125-cm3/1254624971A1KVMOMOSU\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/divers/125-cm3/1254497227A1KVMOMOZZ\n",
-      "1. saved page id: 1254671614\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/650-cm3/1254347020A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/daelim/125-cm3/1254274777A1KVMOMODA\n",
-      "2. saved page id: 1254670217\n",
-      "3. saved page id: 1254670018\n",
-      "4. saved page id: 1252828779\n",
-      "5. saved page id: 1254661446\n",
-      "6. saved page id: 1254634230\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/900-cm3/1253638180A1KVMOMOYA\n",
-      "7. saved page id: 1254658639\n",
-      "8. saved page id: 1254656570\n",
-      "9. saved page id: 1254656505\n",
-      "10. saved page id: 1254651889\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/bmw/1200-cm3/1253979582A1KVMOMOBM\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/689-cm3/1253978698A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/suzuki/650-cm3/1253977270A1KVMOMOSU\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/harley-davidson/1680-cm3/1253977145A1KVMOMOHD\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/900-cm3/1253976914A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/kawasaki/1000-cm3/1253889260A1KVMOMOKA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/royal-enfield/535-cm3/1253917685A1KVMOMORE\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/1300-cm3/1253962187A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/harley-davidson/1690-cm3/1253870175A1KVMOMOHD\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/900-cm3/1253973918A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/harley-davidson/1690-cm3/1253971839A1KVMOMOHD\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/triumph/900-cm3/1246648333A1KVMOMOTR\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/kawasaki/1043-cm3/1253894110A1KVMOMOKA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/suzuki/1800-cm3/1253963695A1KVMOMOSU\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/ducati/1198-cm3/1250913038A1KVMOMODU\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/1000-cm3/1253292109A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/divers/1253190362A1KVMOMOZZ\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/1796-cm3/1254582911A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/harley-davidson/883-cm3/1254582632A1KVMOMOHD\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/1800-cm3/1254581793A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/kawasaki/1400-cm3/1254485663A1KVMOMOKA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamasaki/50-cm3/1254579604A1KVMOMOYI\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/mash/250-cm3/1254579380A1KVMOMOMA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/125-cm3/1254569135A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/harley-davidson/1200-cm3/1254568302A1KVMOMOHD\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/suzuki/599-cm3/1254568226A1KVMOMOSU\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/bmw/1170-cm3/1254506010A1KVMOMOBM\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/125-cm3/1253105983A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/ducati/848-cm3/1254565780A1KVMOMODU\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/mv-agusta/600-cm3/1254565801A1KVMOMOMV\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/kymco/125-cm3/1254591951A1KVMOMOKY\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/500-cm3/1254596589A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/1000-cm3/1254595896A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/1000-cm3/1254595383A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/125-cm3/1254595451A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/125-cm3/1254594284A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/ducati/916-cm3/1254591947A1KVMOMODU\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/daelim/125-cm3/1247266630A1KVMOMODA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/harley-davidson/883-cm3/1254591228A1KVMOMOHD\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/bmw/310-cm3/1254590812A1KVMOMOBM\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/500-cm3/1254290138A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/1000-cm3/1253798400A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/bmw/1200-cm3/1253586439A1KVMOMOBM\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/1800-cm3/1252853753A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/harley-davidson/883-cm3/1254589153A1KVMOMOHD\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/1000-cm3/1254603706A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamasaki/750-cm3/1254603594A1KVMOMOYI\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/ycf/125-cm3/1254603003A1KVMOMOYC\n",
-      "11. saved page id: 1254189986\n",
-      "12. saved page id: 1253980001\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/harley-davidson/1690-cm3/1253732926A1KVMOMOHD\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/125-cm3/1253249545A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/suzuki/750-cm3/1254597783A1KVMOMOSU\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/kawasaki/650-cm3/1254597554A1KVMOMOKA\n",
-      "13. saved page id: 1254187187\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/kawasaki/750-cm3/1253292112A1KVMOMOKA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/125-cm3/1254598146A1KVMOMOHO\n",
-      "14. saved page id: 1254144727\n",
-      "15. saved page id: 1254093860\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/mash/397-cm3/1254597145A1KVMOMOMA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/800-cm3/1253279171A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/1500-cm3/1253291340A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/750-cm3/1254169060A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/harley-davidson/1584-cm3/1254468897A1KVMOMOHD\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/700-cm3/1254614414A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/suzuki/599-cm3/1254613522A1KVMOMOSU\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/600-cm3/1254613306A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/suzuki/125-cm3/1254611957A1KVMOMOSU\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/700-cm3/1254611239A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/suzuki/750-cm3/1254610370A1KVMOMOSU\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/600-cm3/1254609893A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/suzuki/1800-cm3/1254605191A1KVMOMOSU\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/daelim/125-cm3/1254602523A1KVMOMODA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/harley-davidson/1690-cm3/1254603849A1KVMOMOHD\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/600-cm3/1254603684A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/bmw/1170-cm3/1253995610A1KVMOMOBM\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/1200-cm3/1254424354A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/1100-cm3/1253417048A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/kawasaki/750-cm3/1253077981A1KVMOMOKA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/bmw/1200-cm3/1253777897A1KVMOMOBM\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/125-cm3/1254268246A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/600-cm3/1254280782A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/divers/1800-cm3/1254608774A1KVMOMOZZ\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/divers/1254608772A1KVMOMOZZ\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/harley-davidson/1251603891A1KVMOMOHD\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/ducati/848-cm3/1254558560A1KVMOMODU\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/hyosung/125-cm3/1251341312A1KVMOMOHY\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/125-cm3/1254425264A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/bmw/1200-cm3/1249067629A1KVMOMOBM\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/500-cm3/1251436525A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/600-cm3/1254632863A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/124-cm3/1254631526A1KVMOMO000\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/124-cm3/1254631430A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/650-cm3/1254631289A1KVMOMOHO\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "16. saved page id: 1248148829\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/847-cm3/1254630154A1KVMOMO000\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/triumph/800-cm3/1254630005A1KVMOMOTR\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/harley-davidson/749-cm3/1254629665A1KVMOMOHD\n",
-      "17. saved page id: 1251175264\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/1500-cm3/1254629343A1KVMOMOHO\n",
-      "18. saved page id: 1254591302\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/honda/349-cm3/1254602801A1KVMOMOHO\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/750-cm3/1254622841A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/divers/125-cm3/1254498449A1KVMOMOZZ\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/kawasaki/900-cm3/1254621900A1KVMOMOKA\n",
-      "19. saved page id: 1254651274\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/mash/125-cm3/1246998729A1KVMOMOMA\n",
-      "20. saved page id: 1254654520\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/125-cm3/1252673583A1KVMOMO000\n",
-      "21. saved page id: 1254607847\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/250-cm3/1253834670A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/suzuki/750-cm3/1254497755A1KVMOMOSU\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/bmw/1200-cm3/1248786818A1KVMOMOBM\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/bmw/1170-cm3/1253854502A1KVMOMOBM\n",
-      "22. saved page id: 1254651864\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/yamaha/175-cm3/1244404037A1KVMOMOYA\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/ducati/1200-cm3/1254636763A1KVMOMODU\n",
-      "23. saved page id: 1254313672\n",
-      "24. saved page id: 1254635516\n",
-      "NO! https://www.paruvendu.fr/a/moto-scooter/moto/buell/1200-cm3/1254630704A1KVMOMOBE\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "page_count = 1\n",
     "for html_file in [file for file in os.listdir(\"pages\") if file.endswith(\"html\")]:\n",

--- a/tresboncoin/data/paruvendu/scraper.py
+++ b/tresboncoin/data/paruvendu/scraper.py
@@ -88,6 +88,26 @@ class paruvendu_page_scraper():
         return url_list
 
 
+    def get_titles_from_pages(self):
+
+        # set empty title list
+        title_list = []
+
+        # extract title
+        step1 = self.page.select('div[class*="lazyload_bloc"]')
+        if len(step1)>0:
+            for k in step1:
+                step2 = k.find_all("h3")
+                if len(step2)>0:
+                    title_list.append(step2[0].text.replace("\n", "").replace("\t", "").replace("Moto ", "").strip())
+                else:
+                    title_list.append(np.nan)
+        else:
+            return None
+        #
+        return title_list
+
+
     ########################
     #### Announce scraper
     ########################

--- a/tresboncoin/data/paruvendu/scraping_annonces.py
+++ b/tresboncoin/data/paruvendu/scraping_annonces.py
@@ -41,6 +41,7 @@ def scraping_annonces():
 
     # load csv if exists or starting from template
     data_paruvendu = "../paruvendu.csv"
+    ad_datafilepath = "../paruvendu_ad.csv"
     #
     if os.path.isfile(data_paruvendu) is False:
         df = paruvendu_announce_template.copy()
@@ -72,10 +73,11 @@ def scraping_annonces():
             page_scrap = paruvendu_page_scraper(page=soup_)
 
             if page_scrap.get_urls_from_pages() != None:
-                for url_single, uniq_id, price_ in zip(page_scrap.get_urls_from_pages(), page_scrap.get_unique_IDs_from_page(), page_scrap.get_prices_from_page()):
+                for url_single, uniq_id, price_, title_ in zip(page_scrap.get_urls_from_pages(), page_scrap.get_unique_IDs_from_page(), page_scrap.get_prices_from_page(), page_scrap.get_titles_from_pages()):
                    if add_the_announce(data, uniq_id, price_):
                        req_uniq = requests.get(url_single, headers = headers)
                        save_page_uniq(source, req_uniq, uniq_id)
+                       save_temporary_data(ad_datafilepath, url_single, uniq_id, price_, title_)
                        time.sleep(1)
                        count += 1
 

--- a/tresboncoin/data/paruvendu/utils.py
+++ b/tresboncoin/data/paruvendu/utils.py
@@ -1,4 +1,7 @@
 import datetime
+import os
+import numpy as np
+import pandas as pd
 
 def save_page_list(site_name, req, page=1):
     datetime_1 = datetime.datetime.now().strftime("%Y-%m-%d_%Hh%M")
@@ -24,3 +27,37 @@ def add_the_announce(df, uniq_id, price):
 
     # else, return true and add
     return True
+
+def save_temporary_data(csv_file_path_, url_, uniq_id_, price_, title_):
+
+    # load csv if exists or starting from template
+    data_path = csv_file_path_
+    #
+    if os.path.isfile(data_path) is False:
+        df =  pd.DataFrame({"url": [np.nan],
+                            "unique id": [np.nan],
+                            "price": [np.nan],
+                            "title": [np.nan]
+                            })
+    else:
+        data = pd.read_csv(data_path)
+        df =  pd.DataFrame({"url": [np.nan],
+                            "unique id": [np.nan],
+                            "price": [np.nan],
+                            "title": [np.nan]
+                            })
+
+    # adding data
+    df["url"] = url_
+    df["unique id"] = uniq_id_
+    df["price"] = price_
+    df["title"] = title_
+
+    # concatenate to csv and write
+    try:
+        data = pd.concat([data, df], axis=0)
+        data.to_csv(path_or_buf = data_path, index=False)
+    except:
+        df.to_csv(path_or_buf = data_path, index=False)
+
+    return


### PR DESCRIPTION
j'ai rajouté une fonction qui permet de sauvegarder les titres des annonces dans les pages de 15 (qui sont parfois plus fournis que dans les pages individuelles)

c'est sauvegardé dans un csv annexe, qui devra être mergé avec le csv initial (je ferai une autre pull request plus tard pour ça)